### PR TITLE
Add -h, --help, --log= CLI options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Added
+
+- Add CLI options and help message.
+
 ## 0.1.1 - 2018-11-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ gem install rnes
 Pass ROM file path to `rnes` executable.
 
 ```sh
-rnes <FILE>
+Usage: rnes [options] <FILE>
 ```
 
 ## Controls

--- a/exe/rnes
+++ b/exe/rnes
@@ -1,10 +1,24 @@
 #!/usr/bin/env ruby
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+require 'optparse'
 require 'rnes'
 
-path = ARGV[0]
+options = ARGV.getopts('h', 'help', 'log:')
+log_file_path = options['log']
+args = ARGV.parse!
+help_message = "Usage: #{$PROGRAM_NAME} [options] <FILE>"
+if options['h'] || options['help']
+  puts help_message
+  exit
+end
+
+path = args.first
+unless path
+  abort help_message
+end
+
 io = File.binread(path)
 bytes = io.bytes
-emulator = Rnes::Emulator.new
+emulator = Rnes::Emulator.new(log_file_path: log_file_path)
 emulator.load_rom(bytes)
 emulator.run

--- a/lib/rnes/emulator.rb
+++ b/lib/rnes/emulator.rb
@@ -5,9 +5,8 @@ require 'rnes/rom_loader'
 
 module Rnes
   class Emulator
-    LOG_FILE_NAME = 'rnes.log'.freeze
-
-    def initialize
+    # @param [String] log_file_path
+    def initialize(log_file_path: nil)
       parts_factory = ::Rnes::PartsFactory.new
       @cpu = parts_factory.cpu
       @cpu_bus = parts_factory.cpu_bus
@@ -16,7 +15,9 @@ module Rnes
       @keypad2 = parts_factory.keypad2
       @ppu = parts_factory.ppu
       @ppu_bus = parts_factory.ppu_bus
-      @logger = ::Rnes::Logger.new(cpu: @cpu, path: LOG_FILE_NAME, ppu: @ppu)
+      if log_file_path
+        @logger = ::Rnes::Logger.new(cpu: @cpu, path: log_file_path, ppu: @ppu)
+      end
     end
 
     # @param [Array<Integer>] rom_bytes


### PR DESCRIPTION
## Expected behavior

### -h

```
$ exe/rnes -h
Usage: exe/rnes [options] [FILE]
$ echo $?
0
```

### --help

```
$ exe/rnes --help
Usage: exe/rnes [options] [FILE]
$ echo $?
0
```

### --log

```
$ exe/rnes --log=rnes.log test.nes
^C
$ ls rnes/log
rnes.log
```

### Missing FILE

```
$ exe/rnes
$ echo $?
1
```